### PR TITLE
Fixed error which occurs when description (or any other field) is returne

### DIFF
--- a/lib/pivotal_to_pdf/simple_text_formatter.rb
+++ b/lib/pivotal_to_pdf/simple_text_formatter.rb
@@ -3,7 +3,7 @@ module PivotalToPdf
     attr_reader :string
     private :string
     def initialize(string)
-      @string = string
+      @string = string.to_s
     end
 
     def output

--- a/spec/pivotal_to_pdf/simple_text_formatter_spec.rb
+++ b/spec/pivotal_to_pdf/simple_text_formatter_spec.rb
@@ -2,23 +2,29 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "spec_helper"))
 
 module PivotalToPdf
   describe SimpleTextFormatter do
-    subject {SimpleTextFormatter.new "a text"}
     describe "#output" do
+      let(:formatter) {SimpleTextFormatter.new "a text"}
       context "when there is no special formatting" do
         it "should return the string" do
-          subject.output.should == "a text"
+          formatter.output.should == "a text"
         end
       end
       context "when there is bold special formatting" do
+	let(:formatter) {SimpleTextFormatter.new "a *special test* text"}
         it "should return the string converted" do
-          formatter = SimpleTextFormatter.new "a *special test* text"
           formatter.output.should == "a <b>special test</b> text"
         end
       end
       context "when there is italic special formatting" do
+        let(:formatter) {SimpleTextFormatter.new "a _special test_ text"}
         it "should return the string converted" do
-          formatter = SimpleTextFormatter.new "a _special test_ text"
           formatter.output.should == "a <i>special test</i> text"
+        end
+      end
+      context "when the text to format is nil" do
+        let(:formatter) {SimpleTextFormatter.new nil}
+        it "should convert to an empty string" do
+          formatter.output.should be_empty
         end
       end
     end


### PR DESCRIPTION
Fixed error which occurs when description (or any other field) is returned nil in Pivotal API.
