### PR TITLE
Allow formatter to be specified using a file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ a sample .pivotal.yml:
 ```yaml
 token: your-api-token-of-pivotal-tracker
 project_id: your-ptroject-id
-formatter: PivotalToPdf::DefaultFormatter
+formatter: /path/to/my_formatter.rb
 ```
 
 The meaning of the ```formatter``` key will be explained in the next section
@@ -78,6 +78,15 @@ formatter: PivotalToPdf::Formatters:MyPrettyHtmlWriter
 The gem will use ```PivotalToPdf::Formatters::MyPrettyHtmlWriter``` to generate the output.
 
 This feature is associated to the [issue #14](pivotal_to_pdf/issues/14). I basically rewrite the code to implement this myself.
+
+You can also specify a formatter using a file path to a ruby file:
+
+```yaml
+
+formatter: /path/to/my_formatter.rb
+```
+
+This file should define a formatter class ```MyFormatter```.
 
 The actual formatters live in a [ seperate gem ](https://github.com/ywen/pivotal_to_pdf-formatters) so that only that gem needs to be updated when needed. Once that gem is updated, you can do:
 

--- a/lib/pivotal_to_pdf/formatter_factory.rb
+++ b/lib/pivotal_to_pdf/formatter_factory.rb
@@ -3,9 +3,21 @@ module PivotalToPdf
     class << self
       def formatter
         config = Configure.new
-        config.respond_to?(:formatter) ? 
-          config.formatter.constantize :
+        if config.respond_to?(:formatter)
+          if File.exist?(config.formatter)
+            load config.formatter
+            formatter_class_name = camelize(File.basename(config.formatter, '.rb'))
+          else
+            formatter_class_name = config.formatter
+          end
+          formatter_class_name.constantize
+        else
           PivotalToPdf::Formatters::Default
+        end
+      end
+
+      def camelize(str)
+        str.split('_').map {|w| w.capitalize}.join
       end
     end
   end

--- a/spec/fixtures/custom_formatter.rb
+++ b/spec/fixtures/custom_formatter.rb
@@ -1,0 +1,2 @@
+class CustomFormatter
+end

--- a/spec/pivotal_to_pdf/formatter_factory_spec.rb
+++ b/spec/pivotal_to_pdf/formatter_factory_spec.rb
@@ -6,21 +6,30 @@ module PivotalToPdf
       before(:each) do
         Configure.stub(:new).and_return config
       end
+
+      let(:config) { double :config }
       
-      context "when the format_class is not defined" do
-        let(:config) { double :config }
+      context "when the formatter is not defined" do
         it "returns the default formatter" do
           FormatterFactory.formatter.should eq(PivotalToPdf::Formatters::Default)
         end
       end
       
-      context "when the format_class is defined" do
-        let(:config) { double :config, :formatter => "PivotalToPdf::AClass" }
-        before(:each) do
-          PivotalToPdf::AClass = Class.new
+      context "formatter is configured as a path to a ruby file" do
+        let(:config) { 
+          double :config, :formatter => File.join(File.dirname(__FILE__), *%w{.. fixtures custom_formatter.rb}) 
+        }
+
+        it "loads the file and returns the formatter with the same name" do
+          FormatterFactory.formatter.should eq(CustomFormatter)
         end
-        
-        it "returns the default formatter" do
+      end
+
+      context "formatter is configured as a class name" do
+        let(:config) { double :config, :formatter => "PivotalToPdf::AClass" }
+
+        it "returns the specified formatter" do
+          PivotalToPdf::AClass = Class.new
           FormatterFactory.formatter.should eq(PivotalToPdf::AClass)
         end
       end


### PR DESCRIPTION
Hi,

I changed the library to allow a formatter to be specified using a filesystem path as well as by a class name. This makes it easier to load an arbitrary formatter file of your choosing. Otherwise it's hard to actually load your own custom formatter.

David