### PR TITLE
Add ability to print multiple stories at once

### DIFF
--- a/bin/pivotal_to_pdf
+++ b/bin/pivotal_to_pdf
@@ -4,9 +4,16 @@ require 'pivotal_to_pdf'
 require 'thor'
 
 class PivotalToPdfApp < Thor
+
   desc "story [STORY_IDs]", "print one or more stories specifed by ID into a PDF file. The card will have a color stripe. The color will be green for features, yellow for chores and red for bugs"
-  def story(story_ids)
-    PivotalToPdf::Main.story *story_ids
+  def story(*story_ids)
+    #what is the right way to accept 1 or more ids with Thor without using options?
+    if(story_ids.empty?)
+      puts 'ERROR: "pivotal_to_pdf story" was called with no arguments'
+      puts 'Usage: "pivotal_to_pdf story [STORY_IDs]"'
+      return
+    end
+    PivotalToPdf::Main.story story_ids
   end
 
   desc "current_iteration", "print stories for the current iteration into a PDF file"

--- a/bin/pivotal_to_pdf
+++ b/bin/pivotal_to_pdf
@@ -5,8 +5,8 @@ require 'thor'
 
 class PivotalToPdfApp < Thor
   desc "story [STORY_IDs]", "print one or more stories specifed by ID into a PDF file. The card will have a color stripe. The color will be green for features, yellow for chores and red for bugs"
-  def story(*story_ids)
-    PivotalToPdf::Main.story story_ids
+  def story(story_ids)
+    PivotalToPdf::Main.story *story_ids
   end
 
   desc "current_iteration", "print stories for the current iteration into a PDF file"

--- a/bin/pivotal_to_pdf
+++ b/bin/pivotal_to_pdf
@@ -4,9 +4,9 @@ require 'pivotal_to_pdf'
 require 'thor'
 
 class PivotalToPdfApp < Thor
-  desc "story STORY_ID", "print a single story specifed by ID into a PDF file. The card will have a color stripe. The color will be green for features, yellow for chores and red for bugs"
-  def story(story_id)
-    PivotalToPdf::Main.story story_id
+  desc "story [STORY_IDs]", "print one or more stories specifed by ID into a PDF file. The card will have a color stripe. The color will be green for features, yellow for chores and red for bugs"
+  def story(*story_ids)
+    PivotalToPdf::Main.story story_ids
   end
 
   desc "current_iteration", "print stories for the current iteration into a PDF file"

--- a/bin/pivotal_to_pdf
+++ b/bin/pivotal_to_pdf
@@ -6,13 +6,8 @@ require 'thor'
 class PivotalToPdfApp < Thor
 
   desc "story [STORY_IDs]", "print one or more stories specifed by ID into a PDF file. The card will have a color stripe. The color will be green for features, yellow for chores and red for bugs"
-  def story(*story_ids)
-    #what is the right way to accept 1 or more ids with Thor without using options?
-    if(story_ids.empty?)
-      puts 'ERROR: "pivotal_to_pdf story" was called with no arguments'
-      puts 'Usage: "pivotal_to_pdf story [STORY_IDs]"'
-      return
-    end
+  def story(story_id, *other_story_ids)
+    story_ids = (other_story_ids || []).unshift(story_id)
     PivotalToPdf::Main.story story_ids
   end
 

--- a/lib/pivotal_to_pdf.rb
+++ b/lib/pivotal_to_pdf.rb
@@ -16,9 +16,9 @@ require 'pivotal_to_pdf/pt-workarounds'
 module PivotalToPdf
   class Main < Thor
     class << self
-      def story(story_id)
-        story = Story.find(story_id)
-        FormatterFactory.formatter.new([ story ]).write_to(story_id)
+      def story(story_ids)
+        stories = Story.find_stories(story_ids)
+        FormatterFactory.formatter.new(stories).write_to("stories")
       end
 
       def current_iteration

--- a/lib/pivotal_to_pdf/story.rb
+++ b/lib/pivotal_to_pdf/story.rb
@@ -1,5 +1,14 @@
 module PivotalToPdf
   class Story < Pivotal
+
+    def self.find_stories(story_ids)
+      stories = []
+      story_ids.each do |id|
+        stories << self.find(id)
+      end
+      stories
+    end
+
     def formatted_labels
       return "" if !self.respond_to?(:labels) || self.labels.nil? || self.labels.empty?
       formatted_output :labels

--- a/spec/pivotal_to_pdf_bin_spec.rb
+++ b/spec/pivotal_to_pdf_bin_spec.rb
@@ -3,8 +3,12 @@ load File.expand_path(File.join(File.dirname(__FILE__), "..", "bin", "pivotal_to
 
 describe 'PivotalToPdf Bin' do
   context "when passed in story sub command" do
-    it "should call story" do
-      PivotalToPdf::Main.should_receive(:story).with(123)
+    it "should call story with more than one id" do
+      PivotalToPdf::Main.should_receive(:story).with([123,234,345])
+      PivotalToPdfApp.start(["story", 123, 234, 345])
+    end
+    it "should call story with one id" do
+      PivotalToPdf::Main.should_receive(:story).with([123])
       PivotalToPdfApp.start(["story", 123])
     end
     it "should not call story when no story id is given" do

--- a/spec/pivotal_to_pdf_spec.rb
+++ b/spec/pivotal_to_pdf_spec.rb
@@ -24,12 +24,12 @@ module PivotalToPdf
       include_examples "formatter fetching"
 
       it "initiates a story" do
-        Story.should_receive(:find_stories).with([23])
+        Story.should_receive(:find_stories).with([23]).and_return story
         Main.story([23])
       end
 
       it "initiates two stories" do
-        Story.should_receive(:find_stories).with([23, 55])
+        Story.should_receive(:find_stories).with([23, 55]).and_return story
         Main.story([23, 55])
       end
 

--- a/spec/pivotal_to_pdf_spec.rb
+++ b/spec/pivotal_to_pdf_spec.rb
@@ -15,27 +15,32 @@ module PivotalToPdf
     end
     describe ".story" do
       let(:story) {double :story}
-      let(:method) { lambda{ Main.story 32 } }
+      let(:method) { lambda{ Main.story([23]) } }
       before(:each) do
-        Story.stub(:find).and_return story
+        Story.stub(:find_stories).and_return story
         Formatters::Default.stub(:new).and_return writer
       end
 
       include_examples "formatter fetching"
-      
+
       it "initiates a story" do
-        Story.should_receive(:find).with(23).and_return story
-        Main.story 23
+        Story.should_receive(:find_stories).with([23])
+        Main.story([23])
+      end
+
+      it "initiates two stories" do
+        Story.should_receive(:find_stories).with([23, 55])
+        Main.story([23, 55])
       end
 
       it "build a pdf writer" do
-        Formatters::Default.should_receive(:new).with([ story ]).and_return writer
-        Main.story 23
+        Formatters::Default.should_receive(:new).with(story).and_return writer
+        Main.story([23])
       end
 
       it "asks the pdf writer to print it" do
         writer.should_receive :write_to
-        Main.story 23
+        Main.story([23])
       end
     end
     describe ".current_iteration" do


### PR DESCRIPTION
Hi Yi,

I am adding this pull request to add the ability to use the "story" command to print multiple stories at once with a single command. It would work as follows:

> pivotal_to_pdf story story_id1 story_id2 .... story_idn

I ran all the specs and they are passing. I do think there is room for improvement in the tests.  Any feedback is welcome and encouraged. I am happy to make modifications.

Thanks!
Scott